### PR TITLE
Using JS exports and imports, instead of concatenating files

### DIFF
--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
   "license": "MIT",
   "private": false,
   "scripts": {
-    "build": "webpack --config webpack.config.js"
+    "build": "webpack --config webpack.config.js",
+    "postversion": "sed -i \"s/^const Version = '[^']*';/const Version = '$npm_package_version';/\" src/history-explorer-card.js && yarn build && git add history-explorer-card.js src/history-explorer-card.js"
   },
   "devDependencies": {
     "webpack": "^5.91.0",

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "MIT",
   "private": false,
   "scripts": {
-    "build": "cat src/*.js > src/index.js; webpack --config webpack.config.js; rm src/index.js"
+    "build": "webpack --config webpack.config.js"
   },
   "devDependencies": {
     "webpack": "^5.91.0",

--- a/src/history-chart-vline.js
+++ b/src/history-chart-vline.js
@@ -3,6 +3,8 @@
 // Chartjs vertical line plugin
 // --------------------------------------------------------------------------------------
 
+import {isMobile} from "./history-explorer-card";
+
 export const vertline_plugin = {
 
     id: 'vertline',

--- a/src/history-chart-vline.js
+++ b/src/history-chart-vline.js
@@ -3,7 +3,7 @@
 // Chartjs vertical line plugin
 // --------------------------------------------------------------------------------------
 
-const vertline_plugin = {
+export const vertline_plugin = {
 
     id: 'vertline',
 

--- a/src/history-csv-exporter.js
+++ b/src/history-csv-exporter.js
@@ -24,7 +24,7 @@ function escapeSeperator(sep, state)
 // Export CSV : history DB
 // --------------------------------------------------------------------------------------
 
-class HistoryCSVExporter {
+export class HistoryCSVExporter {
 
     constructor() 
     {
@@ -144,7 +144,7 @@ class HistoryCSVExporter {
 // Export CSV : statistics DB
 // --------------------------------------------------------------------------------------
 
-class StatisticsCSVExporter {
+export class StatisticsCSVExporter {
 
     constructor() 
     {

--- a/src/history-default-colors.js
+++ b/src/history-default-colors.js
@@ -3,7 +3,7 @@
 // Default colors for line graphs
 // --------------------------------------------------------------------------------------
 
-var defaultColors = [
+export const defaultColors = [
 
     { 'color': '#3e95cd', 'fill': 'rgba(151,187,205,0.15)' },
     { 'color': '#95cd3e', 'fill': 'rgba(187,205,151,0.15)' },
@@ -23,7 +23,7 @@ var defaultColors = [
 // Predefined state colors for timeline history
 // --------------------------------------------------------------------------------------
 
-const defaultGood = '#66a61e';
+export const defaultGood = '#66a61e';
 const defaultBad = '#b5342d';
 const defaultMultiple = '#e5ad23';
 
@@ -32,10 +32,10 @@ const activeGreen = '#3ecd3e';
 const multipleRed = 'rgb(213, 142, 142)';
 const multipleGreen = 'rgb(142, 213, 142)';
 
-const defaultInactiveLight = '#dddddd';
-const defaultInactiveDark = '#383838';
+export const defaultInactiveLight = '#dddddd';
+export const defaultInactiveDark = '#383838';
 
-const stateColors = { 
+export const stateColors = {
 
     // Special states
 
@@ -124,7 +124,7 @@ const stateColors = {
 
 };
 
-const stateColorsDark = { 
+export const stateColorsDark = {
 
     'off' : defaultInactiveDark, 
 
@@ -132,14 +132,14 @@ const stateColorsDark = {
 
 };
 
-function parseColor(c)
+export function parseColor(c)
 {
     if( c && c.constructor == Object ) return c;
     while( c && c.startsWith('--') ) c = getComputedStyle(document.body).getPropertyValue(c);
     return c;
 }
 
-function parseColorRange(r, v)
+export function parseColorRange(r, v)
 {
     let c, c1, m, n;
 
@@ -151,4 +151,3 @@ function parseColorRange(r, v)
 
     return c ?? c1;
 }
-

--- a/src/history-explorer-card.js
+++ b/src/history-explorer-card.js
@@ -7,7 +7,7 @@ import "../deps/FileSaver.js"
 
 import { vertline_plugin } from "./history-chart-vline.js";
 import { HistoryCSVExporter, StatisticsCSVExporter } from "./history-csv-exporter.js";
-import { stateColors, stateColorsDark, parseColor, parseColorRange } from "./history-default-colors.js";
+import { stateColors, stateColorsDark, defaultColors, parseColor, parseColorRange } from "./history-default-colors.js";
 import { setLanguage, i18n } from "./languages.js";
 import "./history-info-panel.js"
 

--- a/src/history-explorer-card.js
+++ b/src/history-explorer-card.js
@@ -16,7 +16,7 @@ var moment = window.HXLocal_moment;
 
 const Version = '1.0.53';
 
-var isMobile = ( navigator.appVersion.indexOf("Mobi") > -1 ) || ( navigator.userAgent.indexOf("HomeAssistant") > -1 );
+export const isMobile = ( navigator.appVersion.indexOf("Mobi") > -1 ) || ( navigator.userAgent.indexOf("HomeAssistant") > -1 );
 
 
 // --------------------------------------------------------------------------------------
@@ -46,14 +46,14 @@ var panstate = {};
 // HA entity history info panel enabled flag
 // --------------------------------------------------------------------------------------
 
-let infoPanelEnabled = !!JSON.parse(window.localStorage.getItem('history-explorer-info-panel'));
+export let infoPanelEnabled = !!JSON.parse(window.localStorage.getItem('history-explorer-info-panel'));
 
 
 // --------------------------------------------------------------------------------------
 // Internal card representation and instance state
 // --------------------------------------------------------------------------------------
 
-class HistoryCardState {
+export class HistoryCardState {
 
     constructor() 
     {

--- a/src/history-explorer-card.js
+++ b/src/history-explorer-card.js
@@ -5,6 +5,12 @@ import "../deps/timeline.js";
 import "../deps/md5.js"
 import "../deps/FileSaver.js"
 
+import { vertline_plugin } from "./history-chart-vline.js";
+import { HistoryCSVExporter, StatisticsCSVExporter } from "./history-csv-exporter.js";
+import { stateColors, stateColorsDark, parseColor, parseColorRange } from "./history-default-colors.js";
+import { setLanguage, i18n } from "./languages.js";
+import "./history-info-panel.js"
+
 var Chart = window.HXLocal_Chart;
 var moment = window.HXLocal_moment;
 

--- a/src/history-info-panel.js
+++ b/src/history-info-panel.js
@@ -1,5 +1,6 @@
 
 import { defaultGood, defaultInactiveLight, defaultInactiveDark, stateColors, stateColorsDark, parseColor } from "./history-default-colors";
+import { infoPanelEnabled, isMobile, HistoryCardState } from "./history-explorer-card";
 
 // --------------------------------------------------------------------------------------
 // Clone of lit html(), don't want to pull in the entire framework

--- a/src/history-info-panel.js
+++ b/src/history-info-panel.js
@@ -1,4 +1,6 @@
 
+import { defaultGood, defaultInactiveLight, defaultInactiveDark, stateColors, stateColorsDark, parseColor } from "./history-default-colors";
+
 // --------------------------------------------------------------------------------------
 // Clone of lit html(), don't want to pull in the entire framework
 // --------------------------------------------------------------------------------------

--- a/src/languages.js
+++ b/src/languages.js
@@ -473,7 +473,7 @@ const lang_ru =
 // Language localization helper functions
 // --------------------------------------------------------------------------------------
 
-var languages = {
+const languages = {
     'en': lang_en,
     'fr': lang_fr,
     'de': lang_de,
@@ -486,16 +486,16 @@ var languages = {
     'ru': lang_ru
 };
 
-var language = 'en';
+let language = 'en';
 
-function setLanguage(l)
+export function setLanguage(l)
 {
     language = 'en';
     let lang = l.replace('-', '_').split('_');
     if( lang && lang.length > 0 && languages[lang[0]] ) language = lang[0];
 }
 
-function i18n(t, a0)
+export function i18n(t, a0)
 {
     let v = t.split('.').reduce((o,i) => o[i], languages[language]);
     if( v === undefined ) 

--- a/webpack.config.js
+++ b/webpack.config.js
@@ -1,6 +1,7 @@
 const TerserPlugin = require('terser-webpack-plugin');
 
 module.exports = {
+  entry: './src/history-explorer-card.js',
   output: {
     filename: '../history-explorer-card.js',
   },


### PR DESCRIPTION
This should close #10, and mean we do normal JS exports and imports between files, rather than concatenating files together.

This makes it more clear which variables are coming from which files, both for humans and for IDEs tracing things.

Should result in no functional changes.

Also, implementing postversion hooks such that `yarn version` will build and release a new version, updating the version number in the source files too